### PR TITLE
Added a Dockerfile with all dependencies needed to build the OS

### DIFF
--- a/asic/os/ulinux_asic_kianv_soc/Dockerfile
+++ b/asic/os/ulinux_asic_kianv_soc/Dockerfile
@@ -1,0 +1,9 @@
+# To use, run the following commands in this directory:
+# 
+# docker build -t ulinux_asic_kianv_soc_builder .
+# docker run -v `pwd`:`pwd` ulinux_asic_kianv_soc_builder kian-build make -C `pwd` all
+
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y build-essential device-tree-compiler cpio rsync file wget unzip bc


### PR DESCRIPTION
Run the following commands will build the OS inside Docker:

```
docker build -t ulinux_asic_kianv_soc_builder .
docker run -v `pwd`:`pwd` ulinux_asic_kianv_soc_builder kian-build make -C `pwd` all
```

The commands are also included at the top of the Dockerfile for reference.