### PR TITLE
Simulate system with qemu + CI

### DIFF
--- a/.github/workflows/build_os_ulinux_rv32ima.yml
+++ b/.github/workflows/build_os_ulinux_rv32ima.yml
@@ -1,4 +1,4 @@
-name: Build OS KianV RV32IMA ASIC Tinytaepout uLinux
+name: Build OS KianV RV32IMA ASIC Tiny Tapeout uLinux
 
 on:
   push:
@@ -10,26 +10,55 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential device-tree-compiler cpio rsync file wget unzip bc
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential device-tree-compiler cpio rsync file wget unzip bc
 
-    - name: Build OS
-      working-directory: asic/os/ulinux_asic_kianv_soc
-      run: make all bootloader
+      - name: Build OS
+        working-directory: asic/os/ulinux_asic_kianv_soc
+        run: make all bootloader
 
-    - name: Prepare artifact
-      working-directory: asic/os/ulinux_asic_kianv_soc
-      run: |
-        mkdir -p artifact_files
-        cp kianv.dtb bootloader/bootloader.bin buildroot/output/images/Image artifact_files
+      - name: Prepare artifact
+        working-directory: asic/os/ulinux_asic_kianv_soc
+        run: |
+          mkdir -p artifact_files
+          cp kianv.dtb bootloader/bootloader.bin buildroot/output/images/Image artifact_files
 
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: ulinux_asic_kianv_soc_firmware
-        path: asic/os/ulinux_asic_kianv_soc/artifact_files
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ulinux_asic_kianv_soc_firmware
+          path: asic/os/ulinux_asic_kianv_soc/artifact_files
+
+  simulate:
+    runs-on: ubuntu-24.04
+    needs: build
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-misc expect
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ulinux_asic_kianv_soc_firmware
+          path: asic/os/ulinux_asic_kianv_soc/artifact_files
+
+      - name: Copy system image
+        working-directory: asic/os/ulinux_asic_kianv_soc
+        run: |
+          rm Image
+          cp artifact_files/Image Image
+
+      - name: Run simulation
+        working-directory: asic/os/ulinux_asic_kianv_soc
+        run: expect test_system.tcl

--- a/asic/os/ulinux_asic_kianv_soc/Makefile
+++ b/asic/os/ulinux_asic_kianv_soc/Makefile
@@ -18,7 +18,7 @@ DTS_FILE ?= bldroot/board/kianv/rv32ima/kianv.dts
 OUTPUT_DTS_FILE ?= bldroot/board/kianv/rv32ima/kianv_updated.dts
 OUTPUT_DTB_FILE ?= ./kianv.dtb
 
-.PHONY: all bootloader build clone-buildroot customize_buildroot clean-bootloader clean help
+.PHONY: all bootloader build clone-buildroot customize_buildroot clean-bootloader clean help sim
 
 all: update-dts build buildroot
 	@echo "Build process completed."
@@ -30,6 +30,7 @@ help:
 	@echo "  all               Build everything (bootloader and Buildroot)"
 	@echo "  bootloader        Build the bootloader with configurable parameters"
 	@echo "  update-dts        Update the DTS file and generate a DTB file"
+	@echo "  sim               Run the QEMU simulation with the generated system image"
 	@echo "  clean             Clean all generated files"
 	@echo "  help              Display this help message"
 	@echo ""
@@ -86,6 +87,9 @@ update-dts: $(DTS_FILE)
 	@echo "Generating DTB file..."
 	@dtc -I dts -O dtb -o $(OUTPUT_DTB_FILE) $(OUTPUT_DTS_FILE)
 	@echo "DTB file generated: $(OUTPUT_DTB_FILE)"
+
+sim:
+	@qemu-system-riscv32 -M virt -bios none -kernel Image -append "rootwait root=/dev/vda ro"  -nographic -cpu rv32,mmu=off
 
 clean-bootloader:
 	@echo "Cleaning bootloader..."

--- a/asic/os/ulinux_asic_kianv_soc/test_system.tcl
+++ b/asic/os/ulinux_asic_kianv_soc/test_system.tcl
@@ -1,0 +1,19 @@
+#!/usr/bin/expect -f
+
+set timeout 10
+
+# Run the simulation
+spawn make sim
+
+# Wait for shell prompt
+expect "/ #"
+send "uname -om\r"
+expect "riscv32 GNU/Linux"
+
+expect "/ #"
+send "cat /etc/os-release\r"
+expect "NAME=Buildroot"
+
+expect "/ #"
+send "halt\r"
+expect "reboot: System halted"


### PR DESCRIPTION
This adds:

1. `make sim` command to start qemu simulation of the firmware
2. An automated test script to test the buildroot Image in simulation. Run with `expect test_system.tcl`
3. CI job for testing the system using the new test_system.tcl script, right after building the system image artifact.

